### PR TITLE
Feature/issue#27

### DIFF
--- a/src/commands/currency.rs
+++ b/src/commands/currency.rs
@@ -17,28 +17,28 @@ struct ErrorData {
     info: String,
 }
 
-//!
-//! ## API Provider
-//! [exchangerate.host](https://exchangerate.host)
-//!
-//! ## API Documentation
-//! [https://exchangerate.host/documentation](https://exchangerate.host/documentation)
-//!
-//! ## API Endpoint
-//! `/convert` – Converts an amount from one currency to another.
-//!
-//! ## Required Parameters
-//! - `access_key`: Your API key (required for authentication).
-//! - `from`: The base currency (e.g., "USD").
-//! - `to`: The target currency (e.g., "EUR").
-//! - `amount`: The amount to convert (e.g., 100.0).
-//!
-//! ## Terms of Use
-//! - An API key is required. You can obtain one by signing up at [exchangerate.host](https://exchangerate.host).
-//! - The free plan allows up to **100 requests per month**.
-//! - Higher tiers are available for increased usage and additional features.
-//! - Usage beyond the free tier may require upgrading to a paid plan.
-//! For more about pricing, visit: [https://exchangerate.host/pricing](https://exchangerate.host/pricing)
+//
+// ## API Provider
+// [exchangerate.host](https://exchangerate.host)
+//
+// ## API Documentation
+// [https://exchangerate.host/documentation](https://exchangerate.host/documentation)
+//
+// ## API Endpoint
+// `/convert` – Converts an amount from one currency to another.
+//
+// ## Required Parameters
+// - `access_key`: Your API key (required for authentication).
+// - `from`: The base currency (e.g., "USD").
+// - `to`: The target currency (e.g., "EUR").
+// - `amount`: The amount to convert (e.g., 100.0).
+//
+// ## Terms of Use
+// - An API key is required. You can obtain one by signing up at [exchangerate.host](https://exchangerate.host).
+// - The free plan allows up to **100 requests per month**.
+// - Higher tiers are available for increased usage and additional features.
+// - Usage beyond the free tier may require upgrading to a paid plan.
+// For more about pricing, visit: [https://exchangerate.host/pricing](https://exchangerate.host/pricing)
 pub async fn handle_currency(bot: Bot, msg: Message, text: String) -> ResponseResult<()> {
 
     let api_key = match env::var("EXCHANGERATE_TOKEN") {

--- a/src/commands/currency.rs
+++ b/src/commands/currency.rs
@@ -17,6 +17,28 @@ struct ErrorData {
     info: String,
 }
 
+//!
+//! ## API Provider
+//! [exchangerate.host](https://exchangerate.host)
+//!
+//! ## API Documentation
+//! [https://exchangerate.host/documentation](https://exchangerate.host/documentation)
+//!
+//! ## API Endpoint
+//! `/convert` – Converts an amount from one currency to another.
+//!
+//! ## Required Parameters
+//! - `access_key`: Your API key (required for authentication).
+//! - `from`: The base currency (e.g., "USD").
+//! - `to`: The target currency (e.g., "EUR").
+//! - `amount`: The amount to convert (e.g., 100.0).
+//!
+//! ## Terms of Use
+//! - An API key is required. You can obtain one by signing up at [exchangerate.host](https://exchangerate.host).
+//! - The free plan allows up to **100 requests per month**.
+//! - Higher tiers are available for increased usage and additional features.
+//! - Usage beyond the free tier may require upgrading to a paid plan.
+//! For more about pricing, visit: [https://exchangerate.host/pricing](https://exchangerate.host/pricing)
 pub async fn handle_currency(bot: Bot, msg: Message, text: String) -> ResponseResult<()> {
 
     let api_key = match env::var("EXCHANGERATE_TOKEN") {

--- a/src/commands/currency.rs
+++ b/src/commands/currency.rs
@@ -80,7 +80,7 @@ pub async fn handle_currency(bot: Bot, msg: Message, text: String) -> ResponseRe
                         parts[2]
                     )
                 } else {
-                    let err_msg = match data.error {
+                    match data.error {
                         None => "⚠️ Failed to fetch currency data. Try again later.".to_string(),
                         Some(msg) => {
                             if msg.code >= 100 && msg.code < 200 {
@@ -90,8 +90,7 @@ pub async fn handle_currency(bot: Bot, msg: Message, text: String) -> ResponseRe
                                 msg.info
                             }
                         }
-                    };
-                    err_msg
+                    }
                 }
             }
             Err(_) => "❌ Couldn't parse currency data.".to_string(),

--- a/src/commands/currency.rs
+++ b/src/commands/currency.rs
@@ -68,7 +68,7 @@ pub async fn handle_currency(bot: Bot, msg: Message, text: String) -> ResponseRe
                 if data.success {
                     format!("🔄 {} {} = {} {}", parts[0], parts[1], data.result.unwrap_or(0.0), parts[2])
                 } else {
-                    let err_msg = match data.error {
+                    match data.error {
                         None => {
                             "⚠️ Failed to fetch currency data. Try again later.".to_string()
                         }
@@ -80,8 +80,8 @@ pub async fn handle_currency(bot: Bot, msg: Message, text: String) -> ResponseRe
                                 msg.info
                             }
                         }
-                    };
-                    err_msg
+                    }
+
                 }
             }
             Err(_) => {


### PR DESCRIPTION
Add API info documentation for currency command.
Clean up the warning from when "returning the result of a `let` binding from a block" in currency.rs