### PR TITLE
Fallback for unrecognized input

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,8 +7,8 @@ pub mod ping;
 pub mod roll;
 pub mod start;
 pub mod time;
-pub mod weather;
 pub mod unrecognized;
+pub mod weather;
 
 use teloxide::prelude::*;
 use teloxide::types::Message;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod roll;
 pub mod start;
 pub mod time;
 pub mod weather;
+pub mod unrecognized;
 
 use teloxide::prelude::*;
 use teloxide::types::Message;

--- a/src/commands/unrecognized.rs
+++ b/src/commands/unrecognized.rs
@@ -1,0 +1,9 @@
+use teloxide::prelude::{Message, ResponseResult};
+use teloxide::requests::Requester;
+use teloxide::Bot;
+
+pub async fn handle_unrecognized(bot: Bot, msg: Message) -> ResponseResult<()> {
+    let text = "Unrecognized input. Use /help for a list of commands.".to_string();
+    bot.send_message(msg.chat.id, text).await?;
+    Ok(())
+}

--- a/src/commands/unrecognized.rs
+++ b/src/commands/unrecognized.rs
@@ -1,6 +1,6 @@
+use teloxide::Bot;
 use teloxide::prelude::{Message, ResponseResult};
 use teloxide::requests::Requester;
-use teloxide::Bot;
 
 pub async fn handle_unrecognized(bot: Bot, msg: Message) -> ResponseResult<()> {
     let text = "Unrecognized input. Use /help for a list of commands.".to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use log::info;
 
 mod commands;
 use commands::{Command, dispatch_command};
-
+use crate::commands::unrecognized::handle_unrecognized;
 // Entry point of the bot.
 // The `#[tokio::main]` macro starts the Tokio async runtime automatically.
 
@@ -38,15 +38,19 @@ async fn main() {
         Err(err) => log::error!("Failed to verify bot identity: {:?}", err),
     }
 
-    // Build the dispatcher that handles incoming Telegram updates
-    Dispatcher::builder(
-        // Cloning the bot is cheap: it's internally reference-counted
-        bot.clone(),
-        Update::filter_message()
+    let command_handler = dptree::entry()
+        .branch(Update::filter_message()
             // Only handle messages that are bot commands
             .filter_command::<Command>()
             // Route matching commands to `handle_command`
-            .endpoint(dispatch_command),
+            .endpoint(dispatch_command))
+        // Fallback for unrecognized commands.
+        .branch(Update::filter_message().endpoint(handle_unrecognized));
+
+    // Build the dispatcher that handles incoming Telegram updates
+    Dispatcher::builder(
+        // Cloning the bot is cheap: it's internally reference-counted
+        bot.clone(), command_handler
     )
     // Handle updates that didn't match any known command
     .default_handler(|upd| async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use dotenv::dotenv;
 use log::info;
 
 mod commands;
-use commands::{Command, dispatch_command};
 use crate::commands::unrecognized::handle_unrecognized;
+use commands::{Command, dispatch_command};
 // Entry point of the bot.
 // The `#[tokio::main]` macro starts the Tokio async runtime automatically.
 
@@ -39,18 +39,21 @@ async fn main() {
     }
 
     let command_handler = dptree::entry()
-        .branch(Update::filter_message()
-            // Only handle messages that are bot commands
-            .filter_command::<Command>()
-            // Route matching commands to `handle_command`
-            .endpoint(dispatch_command))
+        .branch(
+            Update::filter_message()
+                // Only handle messages that are bot commands
+                .filter_command::<Command>()
+                // Route matching commands to `handle_command`
+                .endpoint(dispatch_command),
+        )
         // Fallback for unrecognized commands.
         .branch(Update::filter_message().endpoint(handle_unrecognized));
 
     // Build the dispatcher that handles incoming Telegram updates
     Dispatcher::builder(
         // Cloning the bot is cheap: it's internally reference-counted
-        bot.clone(), command_handler
+        bot.clone(),
+        command_handler,
     )
     // Handle updates that didn't match any known command
     .default_handler(|upd| async move {


### PR DESCRIPTION
 Add a fallback for unrecognized input.

Currently, I put the endpoint for unrecognized input under command, which is not a proper way to put it. If you have any preference where I should put this default answer, please do tell me. 

Nb: This will also handle the non-command input. If it needs to specify for the command only, please let me know.