### PR TITLE
Issue#12 - Fix error when city not found in /weather

### DIFF
--- a/src/commands/weather.rs
+++ b/src/commands/weather.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use log::info;
 use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 use teloxide::{prelude::*, types::Message};
@@ -49,7 +49,7 @@ pub async fn handle_weather(bot: Bot, msg: Message, city: String) -> ResponseRes
                     Err(_) => "❌ Couldn't parse weather data.".to_string(),
                 }
             } else {
-                debug!("Invalid city name: {}", city);
+                info!("Invalid city name: {}", city);
                 "⚠️ Sorry, We couldn't find that city.".to_string()
             }
         }

--- a/src/commands/weather.rs
+++ b/src/commands/weather.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 use teloxide::{prelude::*, types::Message};
@@ -48,6 +49,7 @@ pub async fn handle_weather(bot: Bot, msg: Message, city: String) -> ResponseRes
                     Err(_) => "❌ Couldn't parse weather data.".to_string(),
                 }
             } else {
+                debug!("Invalid city name: {}", city);
                 "⚠️ Sorry, We couldn't find that city.".to_string()
             }
         }

--- a/src/commands/weather.rs
+++ b/src/commands/weather.rs
@@ -1,4 +1,4 @@
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 use teloxide::{prelude::*, types::Message};
 
@@ -22,24 +22,35 @@ struct WeatherDesc {
 }
 
 pub async fn handle_weather(bot: Bot, msg: Message, city: String) -> ResponseResult<()> {
+    if city.is_empty() {
+        let reply = "⚠️ Please enter a valid city name.".to_string();
+        bot.send_message(msg.chat.id, reply).await?;
+        return Ok(());
+    }
+
     let url = format!("https://wttr.in/{}?format=j1", city);
 
     let client = Client::new();
     let response = client.get(&url).send().await;
-
     let reply = match response {
-        Ok(resp) => match resp.json::<WeatherData>().await {
-            Ok(data) => {
-                let temp = &data.current_condition[0].temp_c;
-                let desc = data.current_condition[0]
-                    .weather_desc
-                    .get(0)
-                    .map(|w| w.value.clone())
-                    .unwrap_or_else(|| "unknown".to_string());
-                format!("🌤️ Weather in {}: {}°C, {}", city, temp, desc)
+        Ok(resp) => {
+            if resp.status() != StatusCode::NOT_FOUND {
+                match resp.json::<WeatherData>().await {
+                    Ok(data) => {
+                        let temp = &data.current_condition[0].temp_c;
+                        let desc = data.current_condition[0]
+                            .weather_desc
+                            .first()
+                            .map(|w| w.value.clone())
+                            .unwrap_or_else(|| "unknown".to_string());
+                        format!("🌤️ Weather in {}: {}°C, {}", city, temp, desc)
+                    }
+                    Err(_) => "❌ Couldn't parse weather data.".to_string(),
+                }
+            } else {
+                "⚠️ Sorry, We couldn't find that city.".to_string()
             }
-            Err(_) => "❌ Couldn't parse weather data.".to_string(),
-        },
+        }
         Err(_) => "⚠️ Failed to fetch weather. Try again later.".to_string(),
     };
 


### PR DESCRIPTION
* Add checking if the message is empty.
* Add error checking if the city is not found by checking the status code. Normally, the wttr will return regardless the city was found or not. To resolve this, we need to check if the status code is 200 or 404.

Note:  Currently, it was unable to give suggestions to users for similar city names since it was not provided in the return of wttr API, except we call another API to handle this.